### PR TITLE
Added real-to-real transformations.

### DIFF
--- a/fftw/src/types.rs
+++ b/fftw/src/types.rs
@@ -1,12 +1,10 @@
 //! Rusty types for manipulating FFTW
 
-use ffi;
-
 pub use ffi::fftw_complex as c64;
 pub use ffi::fftwf_complex as c32;
 
 /// Expose the kinds of real-to-real transformations
-pub type R2RKind = ffi::fftw_r2r_kind;
+pub use ffi::fftw_r2r_kind as R2RKind;
 
 /// Direction of Complex-to-Complex transformation
 #[repr(i32)]

--- a/fftw/tests/r2r.rs
+++ b/fftw/tests/r2r.rs
@@ -1,0 +1,55 @@
+extern crate fftw;
+extern crate num_traits;
+
+use fftw::plan::*;
+use fftw::types::*;
+use num_traits::Zero;
+
+/// Check successive forward and backward transform equals to the identity
+#[test]
+fn r2r2r_identity() {
+    let n = 32;
+    let mut a = vec![0.0f64; n];
+    let mut b = vec![0.0f64; n];
+
+    // http://www.fftw.org/fftw3_doc/Real_002dto_002dReal-Transform-Kinds.html,
+    // contains the normalization rules for each R2R transform. Given
+    // normalization `N`, we can test `inverse_dct(dct(x / N)) == x`.
+    // If you want to apply the normalization symmetrically in the transform
+    // and inverse, then simply divide all elements of the output (or input)
+    // vector by `sqrt(N)`, both on the forward and inverse passes. We
+    // demonstrate this here.
+
+    // Here we use a type-2 DCT, whose inverse is a type-3 DCT, and whose
+    // normalization is `N=2*n`.
+    let mut fwd: R2RPlan64 =
+        R2RPlan::new(&[n], &mut a, &mut b, R2RKind::FFTW_REDFT10, Flag::Measure).unwrap();
+    let mut bwd: R2RPlan64 =
+        R2RPlan::new(&[n], &mut b, &mut a, R2RKind::FFTW_REDFT01, Flag::Measure).unwrap();
+    let N = 2. * n as f64;
+
+    // Vector of ones.
+    a = vec![1.0f64; n];
+
+    // Forward pass.
+    fwd.r2r(&mut a, &mut b).unwrap();
+    // Renormalize
+    for mut i in &mut b {
+        *i /= N.sqrt();
+    }
+
+    // Inverse.
+    bwd.r2r(&mut b, &mut a).unwrap();
+    // Renormalize.
+    for mut i in &mut a {
+        *i /= N.sqrt();
+    }
+
+    // Ensure we have the original vector of ones.
+    for v in a.iter() {
+        let dif = (v - 1.).abs();
+        if dif > 1e-7 {
+            panic!("Large difference: v={}, dif={}", v, dif);
+        }
+    }
+}


### PR DESCRIPTION
FFTW provides a set of real-to-real transformations which are not currently exposed in the Rust API. This PR adds a R2RPlan trait with appropriate implementations, exposing operations like DCT/DST.