### PR TITLE
Upgrade license to GPL v2.0 or later

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -5,8 +5,8 @@ License of fftw, fftw-sys crates
 
 FFTW
 ------
-FFTW is free software and distributed under [GNU General Public License version 2 (GPLv2)](https://www.gnu.org/licenses/gpl-2.0.html),
-and FFI codes (`fftw-sys` crate) and Rust binding (`fftw` crate) are also distributed under GPLv2.
+FFTW is free software and distributed under [GNU General Public License version 2 (GPLv2)](https://www.gnu.org/licenses/gpl-2.0.html) or (at your option) any later version,
+and FFI codes (`fftw-sys` crate) and Rust binding (`fftw` crate) are also distributed under GPLv2 or later.
 
 Intel MKL
 ---------

--- a/fftw-src/Cargo.toml
+++ b/fftw-src/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 description = "Source of FFTW"
 repository = "https://github.com/termoshtt/rust-fftw3"
 keywords = ["fftw"]
-license = "GPL-2.0"
+license = "GPL-2.0-or-later"
 
 build = "build.rs"
 links = "fftw3"


### PR DESCRIPTION
I kindly ask you to upgrade license to "GPL v2.0 or later" both in current 0.6.x branch and 0.5.x branch that is currently the last version compiling on macOS #73

FFTW library is distributed under [GPL v2.0 or later License](http://www.fftw.org/doc/License-and-Copyright.html) that allows users of FFTW to use GPL v3.0. GPL v3.0 has some advantages, for example [it is compatible with Apache v2.0](https://www.apache.org/licenses/GPL-compatibility.html) which is [widely used by Rust crates](https://crates.io/search?page=1&per_page=10&q=license%3AApache-2.0)