### PR TITLE
Fix fftw-src build on macOS

### DIFF
--- a/fftw-src/build.rs
+++ b/fftw-src/build.rs
@@ -97,7 +97,7 @@ fn download_archive_unix(out_dir: &Path) -> Fallible<()> {
 }
 
 fn build_fftw(flags: &[&str], src_dir: &Path, out_dir: &Path) {
-    run(Command::new("./configure")
+    run(Command::new(fs::canonicalize(src_dir.join("configure")).unwrap())
         .arg("--with-pic")
         .arg("--enable-static")
         .arg(format!("--prefix={}", out_dir.display()))


### PR DESCRIPTION
Fixes #73 

I don't know why, but execution of any external shell script on macOS by `Command::new("./script.sh").status()` returns `Error` with `No such file or directory (os error 2)` message. It could be fixed by run `/bin/sh` and pass `script.sh` as an argument