### PR TITLE
Fix unsoundness: Validate input to C2CPlan::c2c and R2RPlan::r2r

### DIFF
--- a/fftw/src/plan.rs
+++ b/fftw/src/plan.rs
@@ -202,6 +202,7 @@ macro_rules! impl_c2c {
                 })
             }
             fn c2c(&mut self, in_: &mut [Self::Complex], out: &mut [Self::Complex]) -> Result<()> {
+                self.check(in_, out)?;
                 unsafe { $exec(self.plan, in_.as_mut_ptr(), out.as_mut_ptr()) };
                 Ok(())
             }
@@ -315,6 +316,7 @@ macro_rules! impl_r2r {
                 })
             }
             fn r2r(&mut self, in_: &mut [Self::Real], out: &mut [Self::Real]) -> Result<()> {
+                self.check(in_, out)?;
                 unsafe { $exec(self.plan, in_.as_mut_ptr(), out.as_mut_ptr()) };
                 Ok(())
             }

--- a/fftw/tests/c2c.rs
+++ b/fftw/tests/c2c.rs
@@ -8,13 +8,18 @@ fn c2c2c_identity() {
     let n = 32;
     let mut a = vec![c64::zero(); n];
     let mut b = vec![c64::zero(); n];
-    let mut plan: C2CPlan64 =
+
+    let mut plan_ab: C2CPlan64 =
         C2CPlan::new(&[n], &mut a, &mut b, Sign::Forward, Flag::MEASURE).unwrap();
+    let mut plan_ba: C2CPlan64 =
+        C2CPlan::new(&[n], &mut b, &mut a, Sign::Forward, Flag::MEASURE).unwrap();
+
     for i in 0..n {
         a[i] = c64::new(1.0, 0.0);
     }
-    plan.c2c(&mut a, &mut b).unwrap();
-    plan.c2c(&mut b, &mut a).unwrap();
+
+    plan_ab.c2c(&mut a, &mut b).unwrap();
+    plan_ba.c2c(&mut b, &mut a).unwrap();
     for v in a.iter() {
         let ans = c64::new(n as f64, 0.0);
         let dif = (v - ans).norm();

--- a/fftw/tests/r2r.rs
+++ b/fftw/tests/r2r.rs
@@ -25,7 +25,9 @@ fn r2r2r_identity() {
     let factor = 2. * n as f64;
 
     // Vector of ones.
-    a = vec![1.0f64; n];
+    for a_i in a.iter_mut() {
+        *a_i = 1.0;
+    }
 
     // Forward pass.
     fwd.r2r(&mut a, &mut b).unwrap();


### PR DESCRIPTION
The underlying C function requires that the arrays passed into it have the same length and alignment as was used to create the plan.
Adding this check prevents out-of-bounds reads and possibly writes.

The same check is already in place for C2R and R2C plans.

Fixes: https://github.com/rust-math/fftw/commit/3e84ddd4f7deb583ff4ca8b47ee266576021fac5
Fixes: https://github.com/rust-math/fftw/commit/862fead9b7e815c7914acccf50106702a89beaff