### PR TITLE
Update repository url

### DIFF
--- a/fftw-src/Cargo.toml
+++ b/fftw-src/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Toshiki Teramura <toshiki.teramura@gmail.com>"]
 edition = "2018"
 
 description = "Source of FFTW"
-repository = "https://github.com/termoshtt/rust-fftw3"
+repository = "https://github.com/rust-math/fftw"
 keywords = ["fftw"]
 license = "GPL-2.0-or-later"
 

--- a/fftw-sys/Cargo.toml
+++ b/fftw-sys/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Toshiki Teramura <toshiki.teramura@gmail.com>"]
 edition = "2018"
 
 description = "unsafe wrapper of FFTW3"
-repository = "https://github.com/termoshtt/rust-fftw3"
+repository = "https://github.com/rust-math/fftw"
 keywords = ["fftw"]
 license-file = "../LICENSE.md"
 

--- a/fftw/Cargo.toml
+++ b/fftw/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Toshiki Teramura <toshiki.teramura@gmail.com>"]
 edition = "2018"
 
 description = "safe wrapper of FFTW3"
-repository = "https://github.com/termoshtt/rust-fftw3"
+repository = "https://github.com/rust-math/fftw"
 keywords = ["fftw"]
 license-file = "../LICENSE.md"
 


### PR DESCRIPTION
The old one redirects to the new one, but still better to say up-to-date.