### PR TITLE
Upgrade intel-mkl-src 0.6, num-complex 0.3

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        feature: ["intel-mkl", "source", "system"]
+        feature: ["source", "system"]
     steps:
     - uses: actions/checkout@v1
     - name: Install system FFTW

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Feature flags
 |:--------|:-----:|:-------:|:-----:|
 |source   |✔️      |✔️        |✔️      |
 |system   |✔️      |-        |✔️      |
-|intel-mkl|✔️      |✔️        |✔️      |
+|intel-mkl|✔️      |✔️        |-      |
 
 LICENSE
 --------

--- a/fftw-sys/Cargo.toml
+++ b/fftw-sys/Cargo.toml
@@ -25,7 +25,7 @@ version = "0.3.0"
 optional = true
 
 [dependencies.intel-mkl-src]
-version = "0.4.0"
+version = "0.6.0"
 optional = true
 
 [package.metadata.docs.rs]

--- a/fftw-sys/Cargo.toml
+++ b/fftw-sys/Cargo.toml
@@ -16,8 +16,8 @@ source = ["fftw-src"]
 intel-mkl = ["intel-mkl-src"]
 
 [dependencies]
-libc = "0.2"
-num-complex = "0.2"
+libc = "0.2.71"
+num-complex = "0.3.0"
 
 [dependencies.fftw-src]
 path = "../fftw-src"


### PR DESCRIPTION
Resolve #90 

- intel-mkl-src 0.6.0+mkl2020.1
  - Drop macOS support as https://github.com/rust-math/intel-mkl-src/issues/42
- num-complex 0.3.0