### PR TITLE
Fix fftw-src build for fs_extra 1.2

### DIFF
--- a/fftw-src/Cargo.toml
+++ b/fftw-src/Cargo.toml
@@ -15,6 +15,6 @@ links = "fftw3"
 [build-dependencies]
 anyhow = "1.0.31"
 cc = "1.0"
-fs_extra = "1.1"
+fs_extra = "~1.2.0"
 ftp = "3.0"
 zip = "0.5"

--- a/fftw-src/build.rs
+++ b/fftw-src/build.rs
@@ -55,6 +55,7 @@ fn build_unix(out_dir: &Path) {
             buffer_size: 64000,
             copy_inside: true,
             depth: 0,
+            content_only: false,
         },
     )
     .unwrap();


### PR DESCRIPTION
I've fixed fs_extra version to 1.2.x.

I'm not sure `content_only: false`.

Fix #99 