### PR TITLE
Add Send + Sync markers for AlignedVec and Plan.

### DIFF
--- a/fftw/src/array.rs
+++ b/fftw/src/array.rs
@@ -102,6 +102,9 @@ where
     }
 }
 
+unsafe impl<T: Send> Send for AlignedVec<T> {}
+unsafe impl<T: Sync> Sync for AlignedVec<T> {}
+
 pub type Alignment = i32;
 
 /// Check the alignment of slice

--- a/fftw/src/plan.rs
+++ b/fftw/src/plan.rs
@@ -36,7 +36,8 @@ pub struct Plan<A, B, Plan: PlanSpec> {
     phantom: PhantomData<(A, B)>,
 }
 
-unsafe impl<A, B, P: PlanSpec> Send for Plan<A, B, P> {}
+unsafe impl<A: Send, B: Send> Send for Plan<A, B, Plan32> {}
+unsafe impl<A: Send, B: Send> Send for Plan<A, B, Plan64> {}
 
 impl<A, B, P: PlanSpec> Drop for Plan<A, B, P> {
     fn drop(&mut self) {

--- a/fftw/src/plan.rs
+++ b/fftw/src/plan.rs
@@ -36,6 +36,8 @@ pub struct Plan<A, B, Plan: PlanSpec> {
     phantom: PhantomData<(A, B)>,
 }
 
+unsafe impl<A, B, P: PlanSpec> Send for Plan<A, B, P> {}
+
 impl<A, B, P: PlanSpec> Drop for Plan<A, B, P> {
     fn drop(&mut self) {
         self.plan.destroy();


### PR DESCRIPTION
`AlignedVec` is definitely safe to be `Send` and `Sync` as it is mutable only behind unique `mut` pointers.

It is harder to reason about `Plan` being `Sync` because we don't know if it uses any `UnsafeCell`-like behaviour internally in `fftw`. However we can be fairly sure it is `Send`, as it will be used in situations that rely on using it in different threads (e.g. in a jack realtime thread).

Using this crate with `jack` is why I need the changes in this PR to use the library.