### PR TITLE
Adds `Serialize` and `Deserialize` implementation to `AlignedVec`

### DIFF
--- a/fftw/Cargo.toml
+++ b/fftw/Cargo.toml
@@ -25,6 +25,9 @@ num-traits = "0.2.12"
 thiserror = "1.0.20"
 serde = { version = "1.0", optional = true}
 
+[dev-dependencies]
+serde_test = "1.0.125"
+
 [dependencies.fftw-sys]
 path = "../fftw-sys"
 version = "0.6.0"

--- a/fftw/Cargo.toml
+++ b/fftw/Cargo.toml
@@ -14,6 +14,7 @@ default = ["source"]
 system = ["fftw-sys/system"]
 source = ["fftw-sys/source"]
 intel-mkl = ["fftw-sys/intel-mkl"]
+serialize = ["num-complex/serde", "serde"]
 
 [dependencies]
 bitflags = "1.2.1"
@@ -22,6 +23,7 @@ ndarray = "0.14.0"
 num-complex = "0.3.0"
 num-traits = "0.2.12"
 thiserror = "1.0.20"
+serde = { version = "1.0", optional = true}
 
 [dependencies.fftw-sys]
 path = "../fftw-sys"

--- a/fftw/src/array.rs
+++ b/fftw/src/array.rs
@@ -102,6 +102,15 @@ where
     }
 }
 
+impl<T> PartialEq for AlignedVec<T> where T:PartialEq{
+    fn eq(&self, other: &Self) -> bool {
+        if self.len() != other.len(){
+            return false
+        }
+        self.iter().zip(other.iter()).all(|(a, b)| a == b)
+    }
+}
+
 unsafe impl<T: Send> Send for AlignedVec<T> {}
 unsafe impl<T: Sync> Sync for AlignedVec<T> {}
 
@@ -116,4 +125,62 @@ pub type Alignment = i32;
 /// ```
 pub fn alignment_of<T>(a: &[T]) -> Alignment {
     unsafe { ffi::fftw_alignment_of(a.as_ptr() as *mut _) }
+}
+
+#[cfg(feature="serialize")]
+mod serde{
+    use super::AlignedVec;
+    use serde::ser::{Serializer, Serialize, SerializeSeq};
+    use serde::{Deserialize, Deserializer};
+    use serde::de::{Visitor, SeqAccess, Unexpected, Error};
+    use std::fmt;
+    use std::marker::PhantomData;
+    use crate::array::AlignedAllocable;
+
+    impl<T> Serialize for AlignedVec<T>
+        where
+            T: Serialize,
+    {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: Serializer,
+        {
+            let mut seq = serializer.serialize_seq(Some(self.len()))?;
+            for e in self.iter() {
+                seq.serialize_element(e)?;
+            }
+            seq.end()
+        }
+    }
+
+    struct AlignedVecVisitor<T>(PhantomData<T>);
+
+    impl<'de, T> Visitor<'de> for AlignedVecVisitor<T> where T: AlignedAllocable + Deserialize<'de>{
+        type Value = AlignedVec<T>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            write!(formatter, "AlignedVec<T>")
+        }
+
+        fn visit_seq<A>(self, seq: A) -> Result<Self::Value, <A as SeqAccess<'de>>::Error> where
+            A: SeqAccess<'de>, {
+            let mut seq = seq;
+            let mut output = AlignedVec::new(
+                seq.size_hint()
+                    .ok_or(A::Error::custom("Failed to retrieve the size of the AlignedVec."))?
+            );
+            for mut val in output.iter_mut(){
+                *val = seq.next_element()?
+                    .ok_or(A::Error::custom("Failed to retrieve the next element"))?
+            }
+            Ok(output)
+        }
+    }
+
+    impl<'de, T> Deserialize<'de> for AlignedVec<T> where T:AlignedAllocable + Deserialize<'de>{
+        fn deserialize<D>(deserializer: D) -> Result<Self, <D as Deserializer<'de>>::Error> where
+            D: Deserializer<'de> {
+            deserializer.deserialize_seq(AlignedVecVisitor(PhantomData))
+        }
+    }
 }

--- a/fftw/src/array.rs
+++ b/fftw/src/array.rs
@@ -183,4 +183,47 @@ mod serde{
             deserializer.deserialize_seq(AlignedVecVisitor(PhantomData))
         }
     }
+
+    #[cfg(test)]
+    mod test {
+        use super::AlignedVec;
+        use serde_test::{Token, assert_tokens};
+        use num_complex::Complex64;
+
+        #[test]
+        fn test_ser_de_empty() {
+            let vec: AlignedVec<Complex64> = AlignedVec::new(0);
+
+            assert_tokens(&vec, &[
+                Token::Seq { len: Some(0) },
+                Token::SeqEnd,
+            ]);
+        }
+
+        #[test]
+        fn test_ser_de() {
+            let mut vec = AlignedVec::new(3);
+            vec[0] = Complex64::new(1., 2.);
+            vec[1] = Complex64::new(3., 4.);
+            vec[2] = Complex64::new(5., 6.);
+
+            assert_tokens(&vec, &[
+                Token::Seq { len: Some(3) },
+                Token::Tuple {len: 2},
+                Token::F64(1.),
+                Token::F64(2.),
+                Token::TupleEnd,
+                Token::Tuple {len: 2},
+                Token::F64(3.),
+                Token::F64(4.),
+                Token::TupleEnd,
+                Token::Tuple {len: 2},
+                Token::F64(5.),
+                Token::F64(6.),
+                Token::TupleEnd,
+                Token::SeqEnd,
+            ]);
+        }
+
+    }
 }


### PR DESCRIPTION
This PR adds an implementation of the `Serialize` and `Deserialize` trait to `AlignedVec`.  An implementation of `PartialEq` was also added since it was mandatory for the tests.

Those would be super useful for us. As we need to save large arrays of data in the Fourier domain.

I chose to hide the implementation behind a `serialize` feature, but I don't mind changing the structure.