### PR TITLE
Planer: non-mutable reference enables threading

### DIFF
--- a/fftw/src/plan.rs
+++ b/fftw/src/plan.rs
@@ -36,6 +36,8 @@ pub struct Plan<A, B, Plan: PlanSpec> {
     phantom: PhantomData<(A, B)>,
 }
 
+unsafe impl<A: Sync, B: Sync> Sync for Plan<A, B, Plan32> {}
+unsafe impl<A: Sync, B: Sync> Sync for Plan<A, B, Plan64> {}
 unsafe impl<A: Send, B: Send> Send for Plan<A, B, Plan32> {}
 unsafe impl<A: Send, B: Send> Send for Plan<A, B, Plan64> {}
 
@@ -97,7 +99,7 @@ pub trait C2CPlan: Sized {
     ) -> Result<Self>;
 
     /// Execute complex-to-complex transform
-    fn c2c(&mut self, in_: &mut [Self::Complex], out: &mut [Self::Complex]) -> Result<()>;
+    fn c2c(&self, in_: &mut [Self::Complex], out: &mut [Self::Complex]) -> Result<()>;
 }
 
 /// Trait for the plan of Real-to-Complex transformation
@@ -124,7 +126,7 @@ pub trait R2CPlan: Sized {
     ) -> Result<Self>;
 
     /// Execute real-to-complex transform
-    fn r2c(&mut self, in_: &mut [Self::Real], out: &mut [Self::Complex]) -> Result<()>;
+    fn r2c(&self, in_: &mut [Self::Real], out: &mut [Self::Complex]) -> Result<()>;
 }
 
 /// Trait for the plan of Complex-to-Real transformation
@@ -151,7 +153,7 @@ pub trait C2RPlan: Sized {
     ) -> Result<Self>;
 
     /// Execute complex-to-real transform
-    fn c2r(&mut self, in_: &mut [Self::Complex], out: &mut [Self::Real]) -> Result<()>;
+    fn c2r(&self, in_: &mut [Self::Complex], out: &mut [Self::Real]) -> Result<()>;
 }
 
 pub trait R2RPlan: Sized {
@@ -175,7 +177,7 @@ pub trait R2RPlan: Sized {
     ) -> Result<Self>;
 
     /// Execute complex-to-complex transform
-    fn r2r(&mut self, in_: &mut [Self::Real], out: &mut [Self::Real]) -> Result<()>;
+    fn r2r(&self, in_: &mut [Self::Real], out: &mut [Self::Real]) -> Result<()>;
 }
 
 macro_rules! impl_c2c {
@@ -204,7 +206,7 @@ macro_rules! impl_c2c {
                     phantom: PhantomData,
                 })
             }
-            fn c2c(&mut self, in_: &mut [Self::Complex], out: &mut [Self::Complex]) -> Result<()> {
+            fn c2c(&self, in_: &mut [Self::Complex], out: &mut [Self::Complex]) -> Result<()> {
                 self.check(in_, out)?;
                 unsafe { $exec(self.plan, in_.as_mut_ptr(), out.as_mut_ptr()) };
                 Ok(())
@@ -242,7 +244,7 @@ macro_rules! impl_r2c {
                     phantom: PhantomData,
                 })
             }
-            fn r2c(&mut self, in_: &mut [Self::Real], out: &mut [Self::Complex]) -> Result<()> {
+            fn r2c(&self, in_: &mut [Self::Real], out: &mut [Self::Complex]) -> Result<()> {
                 self.check(in_, out)?;
                 unsafe { $exec(self.plan, in_.as_mut_ptr(), out.as_mut_ptr()) };
                 Ok(())
@@ -280,7 +282,7 @@ macro_rules! impl_c2r {
                     phantom: PhantomData,
                 })
             }
-            fn c2r(&mut self, in_: &mut [Self::Complex], out: &mut [Self::Real]) -> Result<()> {
+            fn c2r(&self, in_: &mut [Self::Complex], out: &mut [Self::Real]) -> Result<()> {
                 self.check(in_, out)?;
                 unsafe { $exec(self.plan, in_.as_mut_ptr(), out.as_mut_ptr()) };
                 Ok(())
@@ -318,7 +320,7 @@ macro_rules! impl_r2r {
                     phantom: PhantomData,
                 })
             }
-            fn r2r(&mut self, in_: &mut [Self::Real], out: &mut [Self::Real]) -> Result<()> {
+            fn r2r(&self, in_: &mut [Self::Real], out: &mut [Self::Real]) -> Result<()> {
                 self.check(in_, out)?;
                 unsafe { $exec(self.plan, in_.as_mut_ptr(), out.as_mut_ptr()) };
                 Ok(())


### PR DESCRIPTION
The plan is not modified by `..._execute_dft` and alike (see https://www.fftw.org/fftw3_doc/Thread-safety.html)
Thus we can pass the plan `&self` by constant reference.

This enables multiple threaded ffts from the same plan.

```rust
    let mut fft2_r2c = R2CPlan32::aligned(&[window_size, window_size], Flag::ESTIMATE).unwrap();
    let mut fft2_c2r = C2RPlan32::aligned(&[window_size, window_size], Flag::ESTIMATE).unwrap();
    frames
        .par_iter_mut()
        .for_each(|(_frame, window_data)| unsafe {
            let frame_shape = [window_data.shape()[0], window_data.shape()[1]];
            let mut window_data_fft = AlignedVec::new((window_size / 2 + 1) * window_size);
            let mut window_data_slice = window_data.as_slice_mut().unwrap();
            fft2_r2c
                .r2c(&mut window_data_slice, &mut window_data_fft)
                .unwrap();
    });
```

