### PR TITLE
Fix doc warning in plan by wrapping hyperlink

### DIFF
--- a/fftw/src/plan.rs
+++ b/fftw/src/plan.rs
@@ -1,7 +1,7 @@
 //! Plan in FFTW
 //!
-//! See also [Using Plans] in the original document
-//! [Using Plans]: http://www.fftw.org/fftw3_doc/Using-Plans.html
+//! See also [Using Plans](http://www.fftw.org/fftw3_doc/Using-Plans.html)
+//! in the original document
 
 use crate::array::{alignment_of, AlignedAllocable, AlignedVec, Alignment};
 use crate::error::*;


### PR DESCRIPTION
When running cargo doc I see the following output:
```
 $ cargo doc
 Documenting fftw v0.8.0 (/Users/russell/projects/rust/fftw3-rs/fftw)
warning: this URL is not a hyperlink
 --> fftw/src/plan.rs:4:20
  |
4 | //! [Using Plans]: http://www.fftw.org/fftw3_doc/Using-Plans.html
  |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: bare URLs are not automatically turned into clickable links
  = note: `#[warn(rustdoc::bare_urls)]` on by default
help: use an automatic link instead
  |
4 | //! [Using Plans]: <http://www.fftw.org/fftw3_doc/Using-Plans.html>
  |                    +                                              +

warning: `fftw` (lib doc) generated 1 warning (run `cargo fix --lib -p fftw` to apply 1 suggestion)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.32s
   Generated /Users/russell/projects/rust/fftw3-rs/target/doc/fftw/index.html and 2 other files
```
This PR just fixes this warning.